### PR TITLE
fix carousel for single movie

### DIFF
--- a/src/components/SingleMovie/SingleMovie.js
+++ b/src/components/SingleMovie/SingleMovie.js
@@ -4,6 +4,9 @@ import { fetchAllData } from '../../apiCalls';
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Mousewheel, Keyboard } from "swiper";
 import "swiper/css";
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import 'swiper/css/scrollbar';
 import "./SingleMovie.css";
 
 class SingleMovie extends Component {


### PR DESCRIPTION
What does this PR do?

- add appropriate swiper imports for CSS to the SingleMovie.js component file.  Imports missing included: 

import 'swiper/css/navigation';
import 'swiper/css/pagination';
import 'swiper/css/scrollbar'

- Now swiper functionality allows for a user to swipe through multiple trailers on the single movie page.  

Where should your reviewer start?

- SingleMovie.js

How was this tested?

- in the browser 

Any background context?

- reviewed the docs for Swiper React Components

Relevant issues?

- N/A

- next steps could be to include a carousel for the main page but the layout works as it currently is

