### PR TITLE
add cypress testing suite for allMovies

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,9 @@
+const { defineConfig } = require("cypress");
+
+module.exports = defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/cypress/e2e/allMovies_spec.cy.js
+++ b/cypress/e2e/allMovies_spec.cy.js
@@ -1,13 +1,11 @@
 describe("Main Movie Page", () => {
   
   beforeEach(() => {
-    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies')
     cy.visit('http://localhost:3000')
   })
 
   it('A user should be able to visit http://localhost:3000 and see the application title', () => {
     cy.get('h1').contains('🍿 Rancid Tomatillos 🎬').should('be.visible')
-    .should('have.length', 1)
   })
 
   it('A user should be able to visit http://localhost:3000 and view a collection of movies', () => {

--- a/cypress/e2e/allMovies_spec.cy.js
+++ b/cypress/e2e/allMovies_spec.cy.js
@@ -1,0 +1,35 @@
+describe("Main Movie Page", () => {
+  
+  beforeEach(() => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies')
+    cy.visit('http://localhost:3000')
+  })
+
+  it('A user should be able to visit http://localhost:3000 and see the application title', () => {
+    cy.get('h1').contains('🍿 Rancid Tomatillos 🎬').should('be.visible')
+    .should('have.length', 1)
+  })
+
+  it('A user should be able to visit http://localhost:3000 and view a collection of movies', () => {
+    cy.get('div').should('have.class', 'movies-container')
+    cy.get('.mini-poster')
+    .should('have.length', 40)
+  })
+
+   it('A user should be able to see all movies, each with their poster, title and rating', () => {
+    cy.get('div').should('have.class', 'movies-container')
+    .get('.mini-poster').should('exist')
+    .get('.card-title').should('exist')
+    .get('.card-rating').should('exist')
+  })
+
+  it('A user should not be able to see movie details for a single movie', () => {
+    cy.get('.movies-container').should('be.visible')
+      .get('.single-movie.container').should('not.exist')
+  })
+
+  it('A user should be able to click on a movie, and be shown additional details about that movie', () => {
+    cy.get('.mini-poster').first().click()
+  })
+   
+})

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,0 +1,5 @@
+describe('empty spec', () => {
+  it('passes', () => {
+    cy.visit('https://example.cypress.io')
+  })
+})

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')


### PR DESCRIPTION
What does this PR do?

- add cypress packages via npm installation 
- add "cypress:open": "cypress open" to scripts inside package.json file
- adds test suite in cypress for the following file:  allMovies_spec.cy.js 
- all tests are passing in this file currently

Where should your reviewer start?

- allMovies_spec.cy.js 

How was this tested?

- in the browser using cypress testing 

Any background context?

- n/a

Relevant issues?

- unable to get `cy.visit('http://localhost:3000/528085')` in the beforeEach() to pass for singleMovie_spec.cy.js however testing movie details page is working for the following test:  `it('A user should see the movie details for a specific movie', () => {
      cy.get('.mini-poster').first().click()
      .get('h2').contains('2067')
      .get('p').contains('Overview: A lowly utility worker is called to the future by a mysterious radio signal, he must leave his dying wife to embark on a journey that will force him to face his deepest fears in an attempt to change the fabric of reality and save humankind from its greatest environmental crisis yet.')
      .get('p').contains('Release Date: 2020-10-01')
      .get('p').contains('Genres: Science FictionThriller')
      .get('p').contains('Runtime: 114 minutes')
    })`

